### PR TITLE
Multi-Core Compression

### DIFF
--- a/brotli-compress.js
+++ b/brotli-compress.js
@@ -1,0 +1,22 @@
+const util = require('util');
+const fs = require('fs');
+const brotli = require('brotli');
+
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+
+async function brotliCompressFile(file, options) {
+    const stat = fs.statSync(file);
+    const content = await readFile(file);
+    const compressedContent = brotli.compress(content, options);
+    if (compressedContent !== null && compressedContent.length < stat.size) {
+        await writeFile(file + '.br', compressedContent);
+        return compressedContent.length;
+    }
+    return stat.size;
+}
+
+process.on('message', async (message) => {
+    const file = await brotliCompressFile(message.name, message.options);
+    process.send(file);
+});

--- a/gzip-compress.js
+++ b/gzip-compress.js
@@ -1,0 +1,60 @@
+const util = require('util');
+const fs = require('fs');
+const zopfli = require('@gfx/zopfli');
+
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+
+async function zopfliCompressFile(file, options) {
+    const stat = fs.statSync(file);
+    const content = await readFile(file);
+
+    let compressed1 = null;
+    let compressed2 = null;
+
+    if (program.zopfliBlocksplittinglast === 'true') {
+        compressed2 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: true, blocksplittingmax: 15 });
+    }
+    else if (program.zopfliBlocksplittinglast === 'both') {
+        compressed1 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: false, blocksplittingmax: 15 });
+        compressed2 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: true, blocksplittingmax: 15 });
+    }
+    else {
+        compressed1 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: false, blocksplittingmax: 15 });
+    }
+
+    if (compressed1 !== null && compressed1.length < stat.size) {
+        if (compressed2 !== null && compressed2.length < compressed1.length) {
+            await writeFile(file + '.gz', compressed2);
+            return compressed2.length;
+        }
+        else {
+            await writeFile(file + '.gz', compressed1);
+            return compressed1.length;
+        }
+    }
+    else if (compressed2 !== null && compressed2.length < stat.size) {
+        await writeFile(file + '.gz', compressed2);
+        return compressed2.length;
+    }
+
+    return stat.size;
+}
+
+function zopfliPromisify(content, options) {
+    return new Promise((resolve, reject) => {
+        zopfli.gzip(content, options, (err, compressedContent) => {
+            if (!err) {
+                resolve(compressedContent);
+            }
+            else {
+                reject(err);
+            }
+        });
+    });
+}
+
+process.on('message', async (message) => {
+    const file = await zopfliCompressFile(message.name, message.options);
+    process.send(file);
+});

--- a/gzip-compress.js
+++ b/gzip-compress.js
@@ -8,21 +8,21 @@ const writeFile = util.promisify(fs.writeFile);
 async function zopfliCompressFile(file, options) {
     const stat = fs.statSync(file);
     const content = await readFile(file);
-
+    
     let compressed1 = null;
     let compressed2 = null;
-
-    if (program.zopfliBlocksplittinglast === 'true') {
+    
+    if (options.zopfliBlocksplittinglast === 'true') {
         compressed2 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: true, blocksplittingmax: 15 });
     }
-    else if (program.zopfliBlocksplittinglast === 'both') {
+    else if (options.zopfliBlocksplittinglast === 'both') {
         compressed1 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: false, blocksplittingmax: 15 });
         compressed2 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: true, blocksplittingmax: 15 });
     }
     else {
         compressed1 = await zopfliPromisify(content, { numiterations: options.numiterations, blocksplitting: true, blocksplittinglast: false, blocksplittingmax: 15 });
     }
-
+    
     if (compressed1 !== null && compressed1.length < stat.size) {
         if (compressed2 !== null && compressed2.length < compressed1.length) {
             await writeFile(file + '.gz', compressed2);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const globby = require('globby');
 const promiseLimit = require('promise-limit')
 const fork = require('child_process').fork;
+const os = require('os');
 const chalk = require('chalk');
 
 const program = require('commander');
@@ -53,7 +54,7 @@ async function compress(algorithm) {
 	const paths = globby.sync([...globs], { onlyFiles: true });
 	const start = Date.now();
 
-	const limit = promiseLimit(program.limit ? program.limit : 2);
+	const limit = promiseLimit(program.limit ? program.limit : os.cpus().length);
 	
 	let results;
 	if (algorithm === 'brotli') {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const globby = require('globby');
 const promiseLimit = require('promise-limit')
-const util = require('util');
+const fork = require('child_process').fork;
 const chalk = require('chalk');
 
 const program = require('commander');
@@ -64,13 +64,13 @@ async function compress(algorithm) {
 		};
 		results = await Promise.all(paths.map(name => limit(() => {
 			return new Promise(function (resolve) {
-				const process = fork('./brotli-compress.js');
+				const child = fork('./brotli-compress.js');
 
-				process.send({ name: name, options: options });
+				child.send({ name: name, options: options });
 
-				process.on('message', (message) => {
-					console.log("got message", message);
-					resolve();
+				child.on('message', (message) => {
+					child.kill();
+					resolve(message);
 				});
 			});
 		})));
@@ -81,13 +81,13 @@ async function compress(algorithm) {
 		};
 		results = await Promise.all(paths.map(name => limit(() => {
 			return new Promise(function (resolve) {
-				const process = fork('./brotli-compress.js');
+				const child = fork('./brotli-compress.js');
 
-				process.send({ name: name, options: options });
+				child.send({ name: name, options: options });
 
-				process.on('message', (message) => {
-					console.log("got message", message);
-					resolve();
+				child.on('message', (message) => {
+					child.kill();
+					resolve(message);
 				});
 			});
 		})));

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function parseArgs(algorithm) {
 		.option('-s, --stats', 'Show statistics')
 		.option('-a, --algorithm <items>', 'Comma separated list of compression algorithms. Supported values are "brotli" and "gzip". Default "brotli,gzip"', items=>items.split(','))
 		.option('-n, --no-default-ignores', 'Do not add default glob ignores')
-		.option('-l, --limit <value>', 'Number of tasks running concurrently. Default 2', parseInt)
+		.option('-l, --limit <value>', 'Number of tasks running concurrently. Default is your total number of cores', parseInt)
 		.option('--zopfli-numiterations <value>', 'Maximum amount of times to rerun forward and backward pass to optimize LZ77 compression cost. Good values: 10, 15 for small files, 5 for files over several MB in size or it will be too slow. Default 15', parseInt)
 		.option('--zopfli-blocksplittinglast <value>', 'If "true", chooses the optimal block split points only after doing the iterative LZ77 compression. If "false", chooses the block split points first, then does iterative LZ77 on each individual block. If "both", first runs with false, then with true and keeps the smaller file. Default "false"')
 		.option('--brotli-mode <value>', '0 = generic, 1 = text (default), 2 = font (WOFF2)', parseInt)

--- a/index.js
+++ b/index.js
@@ -78,10 +78,11 @@ async function compress(algorithm) {
 	else {
 		const options = {
 			numiterations: program.zopfliNumiterations != null ? program.zopfliNumiterations : 15,
+			zopfliBlocksplittinglast: program.zopfliBlocksplittinglast,
 		};
 		results = await Promise.all(paths.map(name => limit(() => {
 			return new Promise(function (resolve) {
-				const child = fork('./brotli-compress.js');
+				const child = fork('./gzip-compress.js');
 
 				child.send({ name: name, options: options });
 


### PR DESCRIPTION
CLOSES #1

I've implemented multithreaded compression using the NodeJS built-in fork function.

I did this with minimal modification to the library. To keep things simple, I'm spinning up a new thread for each file, and killing it after that file is complete. I changed the default thread limit (previously promise limit) to read the system CPU count.

It would be more efficient to spin up the threads before the job starts, and only close them after all files have been processed. Each thread would tackle the next available file and only close after no files are left to claim. This would require further modification of the library, however. If you want me to implement it this way, I will.